### PR TITLE
Fixed corner case for READ_STATE and PHONE_CALL

### DIFF
--- a/custompermissionsdialogue/src/main/java/stream/custompermissionsdialogue/PermissionsDialogue.java
+++ b/custompermissionsdialogue/src/main/java/stream/custompermissionsdialogue/PermissionsDialogue.java
@@ -676,6 +676,7 @@ public class PermissionsDialogue extends DialogFragment {
             //  but, if they supplied a description then I'll included READ_PHONE_STATE because they show different reasons.
             if ((phone != phonestate && (phone != NOTREQUIRED && phone != REQUIRED)) ||
                     (phone == OPTIONAL && phonestate == OPTIONAL) ||
+                    (TextUtils.isEmpty(phonestatedescription) && (phone != phonestate && phone != REQUIRED))  ||
                     (!TextUtils.isEmpty(phonestatedescription) && !phonestatedescription.equalsIgnoreCase(phonedescription))) {
                 return phonestate;
             }


### PR DESCRIPTION
Fixed corner case for READ_STATE and PHONE_CALL when READ_STATE is required, PHONE_CALL is not required and description for READ_STATE is null.

Sorry, it was a missed paste error in my private version